### PR TITLE
Bump to Xcode 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
       before_install:
         - brew update
         - brew install rocksdb


### PR DESCRIPTION
Update to the latest Xcode. The Docker build also now includes RocksDB 4.13.4 (cc jatoben/swiftrocks@562dfc3).